### PR TITLE
Fix Russian comment for white cells

### DIFF
--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -20,7 +20,7 @@ export class Board {
                 if ((i + j) % 2 !== 0) {
                     row.push(new Cell(this, j, i, Colors.BLACK, null)) // Черные ячейки
                 } else {
-                    row.push(new Cell(this, j, i, Colors.WHITE, null)) // белые
+                    row.push(new Cell(this, j, i, Colors.WHITE, null)) // Белые ячейки
                 }
             }
             this.cells.push(row);


### PR DESCRIPTION
## Summary
- clarify Russian comment for white squares on the chess board

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5111f90c8328b65c0d996d596aa5